### PR TITLE
Set VIP in globals.yml

### DIFF
--- a/main.yaml
+++ b/main.yaml
@@ -199,3 +199,10 @@
         line: "{{hostvars[item]['instance_private_v4']}} {{item}}"
         state: present
       with_items: "{{ groups['all'] }}"
+
+    - name: Set VIP in global.yml
+      lineinfile:
+        dest: /etc/kolla/globals.yml
+        regexp: '^kolla_internal_vip_address:.*$'
+        line: 'kolla_internal_vip_address: "{{internal_vip_address}}"'
+        state: present


### PR DESCRIPTION
In order to keep everything in sync, set the VIP address in globals.yml
with ansible.  The user may still want to set the version of things to
be deployed, but at least the VIP will be the same that was setup in the
cluster.