### PR TITLE
Add .ansible.cfg, and set VIP

### DIFF
--- a/.ansible.cfg
+++ b/.ansible.cfg
@@ -1,0 +1,3 @@
+[ssh_connection]
+timeout=10
+retries=5

--- a/main.yaml
+++ b/main.yaml
@@ -180,9 +180,6 @@
         name: git+https://github.com/openstack/kolla.git@{{kolla_version}}
         editable: False
 
-    - name: Install docker
-      raw: test -e /usr/bin/docker || (curl https://get.docker.com/ | bash)
-
     - name: Link the kolla's configuration files in /etc
       file:
         src: /usr/local/share/kolla/etc_examples/kolla
@@ -208,4 +205,11 @@
         dest: /etc/kolla/globals.yml
         regexp: '^kolla_internal_vip_address:.*$'
         line: 'kolla_internal_vip_address: "{{internal_vip_address}}"'
+        state: present
+
+    - name: Disable StrictHostKeyChecking
+      lineinfile:
+        dest: /etc/ssh/ssh_config
+        regexp: '.*StrictHostKeyChecking .*'
+        line: 'StrictHostKeyChecking no'
         state: present

--- a/main.yaml
+++ b/main.yaml
@@ -180,6 +180,9 @@
         name: git+https://github.com/openstack/kolla.git@{{kolla_version}}
         editable: False
 
+    - name: Install docker
+      raw: test -e /usr/bin/docker || (curl https://get.docker.com/ | bash)
+
     - name: Link the kolla's configuration files in /etc
       file:
         src: /usr/local/share/kolla/etc_examples/kolla


### PR DESCRIPTION
In order to keep everything in sync, set the VIP address in globals.yml
with ansible.  The user may still want to set the version of things to be
deployed, but at least the VIP will be the same that was setup in the
cluster.